### PR TITLE
feat: docker ignore para el despliegue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Ignorar todo esto:
+**/.next
+**/node_modules
+**/.git
+**/.env*.local
+**/.DS_Store
+**/npm-debug.log
+**/yarn-error.log
+**/coverage
+**/.idea
+.vscode/


### PR DESCRIPTION
Solo se agrega el docker ignore para mejorar la construcción y el despliegue de las imágenes